### PR TITLE
Set up WebSocket for private chats

### DIFF
--- a/EventPlanner/src/main/java/com/example/eventplanner/config/WebSocketConfig.java
+++ b/EventPlanner/src/main/java/com/example/eventplanner/config/WebSocketConfig.java
@@ -1,23 +1,15 @@
 package com.example.eventplanner.config;
 
-import ch.qos.logback.classic.pattern.MessageConverter;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.messaging.converter.DefaultContentTypeResolver;
-import org.springframework.messaging.converter.MappingJackson2MessageConverter;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
-import org.springframework.util.MimeTypeUtils;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
-import java.util.List;
-
-import static org.springframework.util.MimeTypeUtils.APPLICATION_JSON;
-
 @Configuration
 @EnableWebSocketMessageBroker
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws").setAllowedOrigins("*");
@@ -25,7 +17,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
-        registry.enableSimpleBroker("/user", "/notifications", "/block");
+        registry.enableSimpleBroker("/private", "/user");
         registry.setApplicationDestinationPrefixes("/app");
         registry.setUserDestinationPrefix("/user");
     }


### PR DESCRIPTION
Fixed WebSocket integration to ensure messages are exchanged exclusively between two users. 

Previously, messages were being broadcasted to all connected users, leading to incorrect behavior where multiple users could see the same messages in a chat.

In this update:
- Implemented private chat channels using user-specific topics.
- Each conversation is now subscribed to a unique topic based on the sender and recipient IDs.
- WebSocket connections are properly managed by ensuring that previous subscriptions are unsubscribed before creating new ones, preventing multiple active connections for the same user.
- Messages are now correctly routed between the sender and recipient without interference from other users.

This ensures that messages are securely exchanged only between the intended users, improving chat functionality and privacy.